### PR TITLE
fix initialize widget variables in the vue component

### DIFF
--- a/app/components/widget-slideshow.vue
+++ b/app/components/widget-slideshow.vue
@@ -109,6 +109,12 @@
         },
         created() {
             this.$options.partials = this.$parent.$options.partials;
+            if(!this.widget.data.config) {
+                this.$set('widget.data.config', []);
+            }
+            if(!this.widget.data.images) {
+                this.$set('widget.data.images', []);
+            }
             this.widget.data.config = _.merge({
                 height: 290,
                 animation: 'slide',


### PR DESCRIPTION
When has created widget and didn't save, every input action in any custom input field cause situation when after focus lost get empty field as result.